### PR TITLE
Don't display inherited physloc notes in Aeon request

### DIFF
--- a/public/models/harvard_aeon/item_mapper.rb
+++ b/public/models/harvard_aeon/item_mapper.rb
@@ -90,7 +90,8 @@ module HarvardAeon
         item_json = item['json']
         ancestor_notes = (item.raw.dig('_resolved_ancestors') || {}).values.flatten.map {|ancestor| ancestor['notes']}.flatten
       end
-      (item_json['notes'] + ancestor_notes).select {|n| n['type'] == 'physloc'}.map {|n| n['content'].join(' ')}.join('; ')
+
+      (item_json['notes'] + ancestor_notes).select {|n| n['type'] == 'physloc' && !n.key?('_inherited')}.map {|n| n['content'].join(' ')}.join('; ')
     end
 
 


### PR DESCRIPTION
This fix prevents the repetition of physical location notes due to inheritance in Aeon requests, while preserving the intended behavior of displaying ancestor level + item level physical location notes.

Old behavior:
<img width="1075" alt="Screen Shot 2021-10-04 at 11 32 19 AM" src="https://user-images.githubusercontent.com/46659222/135880455-7d15ad0e-0ce4-4968-804b-1f52700fcb24.png">

New Behavior:
<img width="1075" alt="Screen Shot 2021-10-04 at 11 32 08 AM" src="https://user-images.githubusercontent.com/46659222/135880473-f5704c13-9e9f-4d93-93be-4e973972fb94.png">

